### PR TITLE
fix: clear router refresh in deliveryInProgress

### DIFF
--- a/src/components/DeliveryInProgress.tsx
+++ b/src/components/DeliveryInProgress.tsx
@@ -22,7 +22,7 @@ export function DeliveryInProgress({
 }: DeliveryProps) {
 	const {
 		packages: { currentPackage },
-		users: { loggedUser },
+		users: { loggedUser, setUserLogged },
 	} = useStore()
 	const router = useRouter()
 
@@ -43,8 +43,11 @@ export function DeliveryInProgress({
 					...currentPackage,
 					status: 'NO ASIGNADO',
 				})
+				//TODO Al cambiar a no asignado sigue apareciendo en la lista de pendientes
+				const updatedUser = await UserServices.getUserById(loggedUser._id)
+				setUserLogged(updatedUser.data)
 				message.success('Paquete eliminado!')
-				router.refresh()
+				router.push('/carrier')
 			}
 		} catch (error) {
 			console.error('Error al eliminar el paquete:', error)

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -76,7 +76,7 @@ export const Login = observer(function () {
 							handleLoginSuccess()
 						} else {
 							message.error(
-								`Lo sentimos ${user.name}. Tu usuario se encuentra bloqueado por incumplimiento de normas`
+								`Lo sentimos ${user.name}. Tu usuario se encuentra bloqueado durante 24hs por incumplimiento de normas`
 							)
 						}
 					} else {


### PR DESCRIPTION
Se elimino el refresh pero aun tiene un bug (el paquete no asignado sigue apareciendo en la lista de pendientes)