### PR TITLE
Feat/show all packages button

### DIFF
--- a/src/app/admin/packages/page.tsx
+++ b/src/app/admin/packages/page.tsx
@@ -47,7 +47,7 @@ export default observer(function AdminPackagesPage() {
 			const packages = await PackageServices.getAllPackages()
 			setPackages(packages)
 		} catch (error) {
-			console.error('Error al eliminar el paquete:', error)
+			console.error('Error al mostrar todos los paquetes:', error)
 			throw error
 		}
 	}

--- a/src/app/admin/packages/page.tsx
+++ b/src/app/admin/packages/page.tsx
@@ -15,11 +15,13 @@ import { observer } from 'mobx-react-lite'
 import { useStore } from 'models/root.store'
 import Link from 'next/link'
 import { useState } from 'react'
+import { PackageServices } from 'services'
+import { message } from 'antd'
 
 export default observer(function AdminPackagesPage() {
 	const [trimmer, setTrimmer] = useState(6)
 	const {
-		packages: { deliveredPackages, packagesByDate },
+		packages: { deliveredPackages, packagesByDate, setPackages },
 		date: { month },
 	} = useStore()
 
@@ -32,6 +34,23 @@ export default observer(function AdminPackagesPage() {
 	const deliveredPAckagesToShow = DELIVERD_PACKAGES.filter(
 		(pack) => pack.isShownToAdmin
 	)
+
+	const handleShowAllPackages = async () => {
+		try {
+			for (const pack of DELIVERD_PACKAGES) {
+				await PackageServices.udapatePackage(pack._id, {
+					...pack,
+					isShownToAdmin: true,
+				})
+			}
+			message.success('Mostrando todos los paquetes')
+			const packages = await PackageServices.getAllPackages()
+			setPackages(packages)
+		} catch (error) {
+			console.error('Error al eliminar el paquete:', error)
+			throw error
+		}
+	}
 
 	const handleTrimmer = () => {
 		if (trimmer === deliveredPackages.length) {
@@ -60,8 +79,12 @@ export default observer(function AdminPackagesPage() {
 					<Title>{selectedDate?.split('-').reverse().join('/')}</Title>
 				</BoxTitle>
 
-				<div className="font-roboto text-xs font-medium p-2 bg-white">
-					{DELIVERD_PACKAGES.length} paquetes entregados{' '}
+				<div className="font-roboto text-xs font-medium p-2 bg-white flex items-center justify-between">
+					Mostrando {deliveredPAckagesToShow.length} de {DELIVERD_PACKAGES.length}{' '}
+					paquetes entregados
+					<Button variant="secondary" onClick={handleShowAllPackages}>
+						Mostrar todos
+					</Button>
 				</div>
 
 				<div className="overflow-scroll max-h-[90%] flex flex-col m-auto">

--- a/src/components/ShipmentView.tsx
+++ b/src/components/ShipmentView.tsx
@@ -1,8 +1,10 @@
 import useModal from 'hooks/useModal'
-import { TitleBox, BoxLayout, ShortArrowIcon } from 'commons'
+import { TitleBox, BoxLayout, ShortArrowIcon, Button } from 'commons'
 import { ShipmentCard } from 'components'
 import { observer } from 'mobx-react-lite'
 import { useStore } from 'models/root.store'
+import { PackageServices, UserServices } from 'services'
+import { message } from 'antd'
 
 interface ShipmentProps {
 	variant?: 'pending' | 'history'
@@ -20,6 +22,7 @@ export const ShipmentView = observer(function ({
 			loggedUser,
 			selectedCarrierDeliveredPackages,
 			selectedCarrierPendingPackages,
+			setUserLogged,
 		},
 	} = useStore()
 
@@ -43,6 +46,25 @@ export const ShipmentView = observer(function ({
 		isCarrier ? pack.isShownToCarrier : pack.isShownToAdmin
 	)
 
+	const handleShowAllPackages = async () => {
+		try {
+			if (packs && loggedUser) {
+				for (const pack of packs) {
+					await PackageServices.udapatePackage(pack._id, {
+						...pack,
+						isShownToCarrier: true,
+					})
+				}
+				message.success('Mostrando todos los paquetes')
+				const updatedUser = await UserServices.getUserById(loggedUser._id)
+				setUserLogged(updatedUser.data)
+			}
+		} catch (error) {
+			console.error('Error al mostrar todos los paquetes: ', error)
+			throw error
+		}
+	}
+
 	const { isModalOpen, toggleModal } = useModal()
 
 	return (
@@ -65,8 +87,11 @@ export const ShipmentView = observer(function ({
 				<section className="p-2 overflow-scroll h-max-[20%]">
 					{variant === 'history' ? (
 						<div>
-							<div className="font-roboto text-xs font-medium p-2">
-								{`${packs?.length} paquetes entregados`}
+							<div className="font-roboto text-xs font-medium pb-2 flex items-center justify-between">
+								{`Mostrando ${packsToShow?.length} de ${packs.length} paquetes entregados`}
+								<Button variant="secondary" onClick={handleShowAllPackages}>
+									Mostrar todos
+								</Button>
 							</div>
 							<hr></hr>
 						</div>


### PR DESCRIPTION
- Se modificó el texto "Mostrando..." indicando cuantos paquetes se están renderizando del total de entregados.
- Se agregó el botón para mostrar todos los paquetes entregados.
- Nueva función para modificar la propiedad de los paquetes y restablecer a true las propiedades de isShownToAdmin y isShownToCarrier, según corresponda.

Admin:
![Screen Shot 2024-01-25 at 16 42 12 PM](https://github.com/Francisco-Villanueva/box-client/assets/137815232/59786479-32e7-4bae-8135-d9a9e2db56f9)

Carrier:
![Screen Shot 2024-01-25 at 19 02 48 PM](https://github.com/Francisco-Villanueva/box-client/assets/137815232/44c5751e-66ce-491e-bde5-d985a8e25b20)
